### PR TITLE
Implement fold in terms of foldMap

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ const {List, Map} = Immutable
 
 const derived = {
   fold : function(empty) {
-    return empty != null
-           ? this.reduce((acc, x) => acc.concat(x), empty)
-           : this.reduce((acc, x) => acc.concat(x))
+    return this.foldMap(x => x, empty)
   },
   foldMap : function(f, empty) {
-    return this.map(f).fold(empty)
+    return empty != null
+           ? this.reduce((acc, x) => acc.concat(f(x)), empty)
+           : this.reduce((acc, x) => acc.concat(f(x)))
   },
   sequence : function(point) {
     return this.traverse(point, x => x)


### PR DESCRIPTION
This allows us to apply the function f as we’re reducing the underlying collection,
saving an extra call to .map(f)