### PR TITLE
fix(traverse): Map.empty and List.empty

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ List.prototype.empty = List.empty
 // traversable
 List.prototype.traverse = function(point, f) {
   return this.reduce((ys, x) =>
-    f(x).map(x => y => y.concat([x])).ap(ys), point(List()))
+    f(x).map(x => y => y.concat([x])).ap(ys), point(this.empty))
 }
 
 List.prototype.sequence = derived.sequence
@@ -64,7 +64,7 @@ Map.prototype.foldMap = derived.foldMap
 // traverable
 Map.prototype.traverse = function(point, f) {
   return this.reduce((acc, v, k) =>
-    f(v, k).map(x => y => y.merge({[k]: x})).ap(acc), point(Map.empty))
+    f(v, k).map(x => y => y.merge({[k]: x})).ap(acc), point(this.empty))
 }
 
 Map.prototype.sequence = derived.sequence


### PR DESCRIPTION
I am not sure if this is a problem with the repo or how I use it. I created my-library that uses `ramda-lens` and `immutable-ext` to traverse my data structures. When I use it from node everything works well, but when I import my-library in a frontend (using webpack). Then, the functions that use  traverse are failing. I tracked down the problem till this changes are solving them. Basically, Map.empty and List.empty are undefined inside `List.prototype.traverse` and `Map.prototype.traverse`

Thanks!