### PR TITLE
Update - make the ES5 version as main entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 
 # Optional REPL history
 .node_repl_history
+
+# Remove dist folder
+dist

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "immutable-ext",
   "version": "1.1.2",
   "description": "fantasyland compatible extensions",
-  "main": "index.js",
+  "main": "dist/index.js",
   "engines": {
     "node": ">=6.2.0"
   },
@@ -13,13 +13,17 @@
     "immutable": "*"
   },
   "devDependencies": {
-    "immutable": "*",
+    "babel-cli": "^6.24.1",
+    "babel-preset-es2015": "^6.24.1",
     "daggy": "^0.0.1",
     "fantasy-identities": "^0.0.1",
+    "immutable": "*",
     "mocha": "^2.4.5"
   },
   "scripts": {
-    "test": "mocha --watch test/**.js"
+    "test": "mocha --watch test/**.js",
+    "compile": "babel --presets es2015 -d dist/ ./index.js",
+    "prepublish": "npm run compile"
   },
   "keywords": [
     "functional",


### PR DESCRIPTION
This PR is to be able to consume this package as pure ES5, as webpack expect ES5 imported modules. If you are happy with this change, could you publish it to NPM as well ? Thank you !