### PR TITLE
improving traverse running order against lists of functions returning tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ List.prototype.empty = List.empty
 // traversable
 List.prototype.traverse = function(point, f) {
   return this.reduce((ys, x) =>
-    f(x).map(x => y => y.concat([x])).ap(ys), point(this.empty))
+    ys.map(x => y => x.concat([y])).ap(f(x)), point(this.empty))
 }
 
 List.prototype.sequence = derived.sequence


### PR DESCRIPTION
This pull request, is to solve #9,  indeed make no observable difference for almost all scenarios. It just bother me sometimes when debugging. 

Given the following passed unit case. Only the running order are reversed when traverse with functions returning tasks. 
```javascript
  it('traverses the list of tasks returning Task', (done) => {
    const Task = require('data.task')
    const buildTask = (n) => new Task((rej, res) => {
      console.log(n) // --> prints 3 2 1, showing it runs in reverse order
      res(n)
    })
    
    const listOfFns = List.of(()=>buildTask(1), ()=>buildTask(2), ()=>buildTask(3))
    listOfFns.traverse(Task.of, f => f())
    .fork(done, x => {
      assert.deepEqual(x, List.of(1,2,3)) // --> it returns in right order 
      done()
    })
  })
```