### PR TITLE
Fix incorrect repo url.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/npm.git"
+    "url": "https://github.com/DrBoolean/immutable-ext.git"
   },
   "engines": {
     "node": ">=6.2.0"


### PR DESCRIPTION
Incorrect repo url is making the NPM page look scary:

<img width="1079" alt="screen shot 2018-04-01 at 21 52 13" src="https://user-images.githubusercontent.com/3373683/38177333-9c306df4-35f7-11e8-9916-f00dd24167d8.png">

Updated the repo url in the package.json, but haven't bumped the version number.